### PR TITLE
replace recordtype using standard Python dataclass tools

### DIFF
--- a/proteus/Context.py
+++ b/proteus/Context.py
@@ -27,7 +27,7 @@ Example (use the global context)::
 """
 from __future__ import print_function
 from collections import  namedtuple
-from recordtype import recordtype
+import dataclasses
 
 from .Profiling import logEvent
 
@@ -55,8 +55,11 @@ def setFromModule(moduleIn,mutable=False):
         if  key[:2] != "__":
             fields[key]=value
     if mutable:
-        Context = recordtype(moduleIn.__name__.split('.')[-1], iter(fields.items()))
-        context = Context()
+        #Context = recordtype(moduleIn.__name__.split('.')[-1], iter(fields.items()))
+        Context = dataclasses.make_dataclass(moduleIn.__name__.split('.')[-1],
+                                             [(k,type(fields[k]), dataclasses.field(default_factory= lambda x=fields[k]: x))
+                                              for k in fields.keys()])
+        context = Context(**fields)
     else:
         Context = namedtuple(moduleIn.__name__.split('.')[-1], list(fields.keys()))
         context = Context._make(list(fields.values()))
@@ -106,8 +109,12 @@ def Options(optionsList=None,mutable=False):
                 logEvent("IGNORING CONTEXT OPTION; DECLARE "+lvalue+" IF YOU WANT TO SET IT")
     #now set named tuple merging optionsList and opts_cli_dihelpct
     if mutable:
-        ContextOptions = recordtype("ContextOptions", iter(contextOptionsDict.items()))
-        return ContextOptions()
+        #ContextOptions = recordtype("ContextOptions", iter(contextOptionsDict.items()))
+        ContextOptions = dataclasses.make_dataclass("ContextOptions",
+                                                    [(k,type(contextOptionsDict[k]), dataclasses.field(default_factory=lambda x=contextOptionsDict[k]: x))
+                                                     for k in contextOptionsDict.keys()])
+
+        return ContextOptions(**contextOptionsDict)
     else:
         ContextOptions = namedtuple("ContextOptions", list(contextOptionsDict.keys()))
         return ContextOptions._make(list(contextOptionsDict.values()))

--- a/proteus/defaults.py
+++ b/proteus/defaults.py
@@ -1,4 +1,4 @@
-import sys, recordtype, os, imp, copy, inspect
+import sys, os, imp, copy, inspect, dataclasses
 from . import (TransportCoefficients,
                Transport,
                default_p,
@@ -52,10 +52,15 @@ for k in (set(dir(default_p)) -
     else:
         physics_excluded_keys.append(k)
 
-_Physics_base = recordtype.recordtype('Physics_base',
-                                     [(k,default_p.__dict__[k])
-                                      for k in physics_default_keys],
-                                     use_slots=False)
+#_Physics_base = recordtype.recordtype('Physics_base',
+#                                     [(k,default_p.__dict__[k])
+#                                      for k in physics_default_keys],
+#                                     use_slots=False)
+_Physics_base = dataclasses.make_dataclass('Physics_base',
+                                           [(k,
+                                             type(default_p.__dict__[k]),
+                                             dataclasses.field(default_factory= lambda x=default_p.__dict__[k]: x))
+                                            for k in physics_default_keys])
 class Physics_base(_Physics_base):
     __frozen = False
 
@@ -143,10 +148,14 @@ for k in (set(dir(default_n)) -
     else:
         numerics_excluded_keys.append(k)
 
-_Numerics_base = recordtype.recordtype('Numerics_base',
-                                      [(k,default_n.__dict__[k])
-                                       for k in numerics_default_keys],
-                                      use_slots=False)
+#_Numerics_base = recordtype.recordtype('Numerics_base',
+#                                      [(k,default_n.__dict__[k])
+#                                       for k in numerics_default_keys],
+#                                      use_slots=False)
+_Numerics_base = dataclasses.make_dataclass('Numerics_base',
+                                            [(k,type(default_n.__dict__[k]), dataclasses.field(default_factory= lambda x=default_n.__dict__[k]: x))
+                                             for k in numerics_default_keys])
+                                            
 class Numerics_base(_Numerics_base):
     __frozen = False
 
@@ -212,10 +221,13 @@ for k in (set(dir(default_so)) -
     else:
         system_excluded_keys.append(k)
 
-_System_base = recordtype.recordtype('System_base',
-                                    [(k,default_so.__dict__[k])
-                                     for k in system_default_keys],
-                                    use_slots=False)
+#_System_base = recordtype.recordtype('System_base',
+#                                    [(k,default_so.__dict__[k])
+#                                     for k in system_default_keys],
+#                                    use_slots=False)
+_System_base = dataclasses.make_dataclass('System_base',
+                                          [(k,type(default_so.__dict__[k]),dataclasses.field(default_factory= lambda x=default_so.__dict__[k]: x))
+                                           for k in system_default_keys])
 
 class System_base(_System_base):
     def __init__(self, **args):


### PR DESCRIPTION
I used the dataclasses module to replace recordtype instead, so we can get rid of the dependency completely. Still needs a little work, and I also see some unrelated test failures using the updated conda env on your branch.